### PR TITLE
Fix loop for efficient copy

### DIFF
--- a/1/main.go
+++ b/1/main.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"fmt"
+	"task1/utils"
+)
+
+func main() {
+	// assigne vars and print them out
+	someIntegerNumbers := utils.GetSomeIntegerNumbers()
+	fmt.Printf("Got integer numbers:\n  - %v\n", someIntegerNumbers)
+
+	firstNumFloat64, secondNumFloat64, thirdNumFloat64 := utils.GetSomeFloat64Numbers()
+	fmt.Printf("Got float64 numbers:\n  - %v\n  - %v\n  - %v\n", firstNumFloat64, secondNumFloat64, thirdNumFloat64)
+
+	someStringOne, someStringTwo := utils.GetSomeStrings()
+	fmt.Printf("Got strings:\n  - %v\n  - %v\n", someStringOne, someStringTwo)
+
+	someBooleanOne, someBooleanTwo := utils.GetSomeBooleans()
+	fmt.Printf("Got boleans:\n  - %v\n  - %v\n", someBooleanOne, someBooleanTwo)
+
+	someComplex64Numbers := utils.GetSomeComplex64Numbers()
+	fmt.Printf("Got complex64 numbers:\n  - %v\n  - %v\n", someComplex64Numbers.First, someComplex64Numbers.Second)
+
+	// get types of vars
+	utils.GetVarType(someIntegerNumbers)
+
+	someIntegerNumbersForVariadicUnpacking := make([]interface{}, len(someIntegerNumbers))
+	for i, v := range someIntegerNumbers {
+		someIntegerNumbersForVariadicUnpacking[i] = v
+	}
+	utils.GetVarType(someIntegerNumbersForVariadicUnpacking...)
+}


### PR DESCRIPTION
Corrected loop iteration for type conversion to resolve a linter error and ensure proper variadic unpacking.

The linter suggested using `copy()`, but it's not suitable here as the loop performs a type conversion from `[]int` to `[]interface{}`, which `copy()` does not support directly.

---
<a href="https://cursor.com/background-agent?bcId=bc-5ff9fcb6-2cef-4d8c-96ac-d19912c0d1e1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5ff9fcb6-2cef-4d8c-96ac-d19912c0d1e1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

