### PR TITLE
Fix string interface{} type mismatch

### DIFF
--- a/1/utils/convert_and_cat.go
+++ b/1/utils/convert_and_cat.go
@@ -1,0 +1,12 @@
+package utils
+
+import "fmt"
+
+func ConvertAndCatToString(args ...interface{}) string {
+	var result string
+	for _, arg := range args {
+		result += fmt.Sprint(arg)
+	}
+
+	return result
+}


### PR DESCRIPTION
Fixes a type mismatch error in `ConvertAndCatToString` by converting `interface{}` arguments to strings before concatenation.

---
<a href="https://cursor.com/background-agent?bcId=bc-bbca73c5-5728-44a6-a0fc-b449308d2dc9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-bbca73c5-5728-44a6-a0fc-b449308d2dc9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

