### PR TITLE
Fix context.WithCancel error

### DIFF
--- a/6/go.mod
+++ b/6/go.mod
@@ -1,0 +1,3 @@
+module example
+
+go 1.21

--- a/6/main.go
+++ b/6/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("Random Generator Example")
+}

--- a/6/utils/utils.go
+++ b/6/utils/utils.go
@@ -1,0 +1,27 @@
+package utils
+
+import (
+	"context"
+	"math/rand"
+	"time"
+)
+
+// RandomGenerator генерирует случайные числа в заданном диапазоне
+func RandomGenerator(ctx context.Context, count, min, max int) <-chan int {
+	ch := make(chan int)
+	
+	go func() {
+		defer close(ch)
+		r := rand.New(rand.NewSource(time.Now().UnixNano()))
+		
+		for i := 0; i < count; i++ {
+			select {
+			case <-ctx.Done():
+				return
+			case ch <- r.Intn(max-min+1) + min:
+			}
+		}
+	}()
+	
+	return ch
+}

--- a/6/utils/utils_test.go
+++ b/6/utils/utils_test.go
@@ -1,0 +1,62 @@
+package utils
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestRandomGenerator_WithContext(t *testing.T) {
+	ctx := t.Context()
+
+	const (
+		count = 1000
+		min   = 1
+		max   = 10
+	)
+
+	randCh := RandomGenerator(ctx, count, min, max)
+
+	for i := 0; i < 10; i++ {
+		num, ok := <-randCh
+		if !ok {
+			t.Error("Channel closed prematurely")
+			return
+		}
+		if num < min || num > max {
+			t.Errorf("Number %d out of range", num)
+		}
+	}
+
+	select {
+	case _, ok := <-randCh:
+		if !ok {
+			t.Error("Channel should not be closed yet")
+		}
+	default:
+	}
+}
+
+func TestRandomGenerator_Cancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+
+	const count = 100000
+	randCh := RandomGenerator(ctx, count, 1, 10)
+
+	cancel()
+
+	time.Sleep(50 * time.Millisecond)
+
+	if num, ok := <-randCh; ok {
+		t.Errorf("Expected closed channel, but got value: %d", num)
+	}
+
+	select {
+	case _, ok := <-randCh:
+		if ok {
+			t.Error("Channel should be closed")
+		}
+	default:
+		t.Error("Channel should be closed and not blocking")
+	}
+}


### PR DESCRIPTION
Modernize context usage in tests by leveraging `t.Context()` to resolve linter warnings.

The `context.WithCancel(context.Background())` pattern in tests triggers a linter warning (`context.WithCancel can be modernized using t.Context`). This PR updates the test contexts to use `t.Context()` where appropriate, which provides a context that is automatically cancelled when the test finishes, aligning with modern Go testing practices. For tests requiring explicit cancellation, `context.WithCancel(t.Context())` is used.

---
<a href="https://cursor.com/background-agent?bcId=bc-291a260d-9457-4bf9-bca5-1496abbde285">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-291a260d-9457-4bf9-bca5-1496abbde285">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

